### PR TITLE
Extract original_transaction_id instead of transaction_id

### DIFF
--- a/src/AppStoreServerLibrary/ReceiptUtility.php
+++ b/src/AppStoreServerLibrary/ReceiptUtility.php
@@ -10,7 +10,7 @@ class ReceiptUtility
 {
     const PKCS7_OID = "1.2.840.113549.1.7.2";
     const IN_APP_ARRAY = 17;
-    const TRANSACTION_IDENTIFIER = 1703;
+    const ORIGINAL_TRANSACTION_IDENTIFIER = 1705;
 
 
     /**
@@ -84,9 +84,9 @@ class ReceiptUtility
                     $type = $currentRead["type"] ?? null;
                     $value = $currentRead["content"] ?? null;
                     if ($type === ASN1::TYPE_INTEGER
-                        && ($value === self::TRANSACTION_IDENTIFIER
+                        && ($value === self::ORIGINAL_TRANSACTION_IDENTIFIER
                             || ($value instanceof BigInteger
-                                && $value->compare(new BigInteger(self::TRANSACTION_IDENTIFIER)) === 0))
+                                && $value->compare(new BigInteger(self::ORIGINAL_TRANSACTION_IDENTIFIER)) === 0))
                     ) {
                         $currentRead = $loopCurrentInApp["content"][2] ?? null;
                         $type = $currentRead["type"] ?? null;


### PR DESCRIPTION
As I understand all transactions should have original_transaction_id.  But this test fails
https://github.com/hoels/app-store-server-library-php/blob/7a4d1b95a1d9db85ac9324c4a1b08274b69f7727/tests/AppStoreServerLibrary/ReceiptUtilityTest.php#L18-L24

I don't know what it tests but my guess is invalid receipt. Anyway, the receipt with transactionId "0" does it even make sense?


```
PHPUnit 10.5.16 by Sebastian Bergmann and contributors.

Runtime:       PHP 8.1.27
Configuration: /var/www/html/apple/app-store-server-library-php/phpunit.xml.dist

..........................F.....................                  48 / 48 (100%)

Time: 00:00.989, Memory: 14.00 MB

There was 1 failure:

1) AppStoreServerLibrary\Tests\ReceiptUtilityTest::testXcodeAppReceiptExtractionWithTransactions
Failed asserting that null matches expected '0'.

/var/www/html/apple/app-store-server-library-php/tests/AppStoreServerLibrary/ReceiptUtilityTest.php:23

FAILURES!
Tests: 48, Assertions: 240, Failures: 1.
```

Also, I tested with many real receipts, and all of them have original_transaction_id and can be parsed and never seen transaction_id "0"